### PR TITLE
Prepare the code to work with rails 7.2

### DIFF
--- a/lib/hstore_translate/translates.rb
+++ b/lib/hstore_translate/translates.rb
@@ -6,7 +6,7 @@ module HstoreTranslate
       include InstanceMethods
 
       class_attribute :translated_attrs
-      alias_attribute :translated_attribute_names, :translated_attrs # Improve compatibility with the gem globalize
+      alias_method :translated_attribute_names, :translated_attrs # Improve compatibility with the gem globalize
       self.translated_attrs = attrs
 
       attrs.each do |attr_name|

--- a/lib/hstore_translate/version.rb
+++ b/lib/hstore_translate/version.rb
@@ -1,3 +1,3 @@
 module HstoreTranslate
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
This PR fixes deprecation warning in Rails 7.1
```DEPRECATION WARNING: X model aliases Y, but Y is not an attribute. Starting in Rails 7.2, alias_attribute with non-attribute targets will raise. Use alias_method```